### PR TITLE
refactor!: make the "end" field the last character instead of the following character

### DIFF
--- a/src/lexer/lex.ts
+++ b/src/lexer/lex.ts
@@ -76,7 +76,7 @@ export default function lex(input: string): Token[] {
                     ZircoSyntaxErrorTypes.UnclosedString,
                     {
                         start,
-                        end: i + 1
+                        end: i
                     },
                     {}
                 );
@@ -88,19 +88,19 @@ export default function lex(input: string): Token[] {
                 if (char === "\\") {
                     // This will add the next character to the string, regardless of what it is, even if it's a ".
                     str += char;
-                    if (i + 1 >= length) throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.UnclosedString, { start: i, end: i + 1 }, {});
+                    if (i + 1 >= length) throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.UnclosedString, { start: i, end: i }, {});
                     char = input[++i];
                 }
 
                 str += char;
 
-                if (i + 1 >= length) throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.UnclosedString, { start, end: i + 1 }, {});
+                if (i + 1 >= length) throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.UnclosedString, { start, end: i }, {});
 
                 char = input[++i];
             }
 
             // We found the end of the string. Let's add it to the output.
-            output.push([`"${str}"`, { type: TokenTypes.String, position: { start, end: i + 1 } }]);
+            output.push([`"${str}"`, { type: TokenTypes.String, position: { start, end: i } }]);
             continue;
         }
 
@@ -119,8 +119,7 @@ export default function lex(input: string): Token[] {
             const typeOfLiteral = char === "x" ? "hexadecimal" : "binary";
             str += char;
 
-            if (i + 1 >= length)
-                throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.NumberPrefixWithNoValue, { start: i, end: i + 1 }, { typeOfLiteral });
+            if (i + 1 >= length) throw new ZircoSyntaxError(ZircoSyntaxErrorTypes.NumberPrefixWithNoValue, { start: i, end: i }, { typeOfLiteral });
 
             const matchReg = char === "b" ? /[01]/ : /[0-9a-fA-F]/;
 
@@ -130,7 +129,7 @@ export default function lex(input: string): Token[] {
                 if (!matchReg.test(char))
                     throw new ZircoSyntaxError(
                         ZircoSyntaxErrorTypes.NumberInvalidCharacter,
-                        { start: i, end: i + 1 },
+                        { start: i, end: i },
                         { typeOfLiteral, invalidCharacter: char }
                     );
 
@@ -138,7 +137,7 @@ export default function lex(input: string): Token[] {
                 if (i + 1 >= length) break;
             }
 
-            output.push([str, { type: TokenTypes.Number, position: { start, end: i + 1 } }]);
+            output.push([str, { type: TokenTypes.Number, position: { start, end: i } }]);
             continue;
         }
 
@@ -152,7 +151,7 @@ export default function lex(input: string): Token[] {
                 if (/[^0-9._]/.test(char))
                     throw new ZircoSyntaxError(
                         ZircoSyntaxErrorTypes.NumberInvalidCharacter,
-                        { start: i, end: i + 1 },
+                        { start: i, end: i },
                         { typeOfLiteral: "decimal", invalidCharacter: char }
                     );
 
@@ -168,14 +167,14 @@ export default function lex(input: string): Token[] {
                     ZircoSyntaxErrorTypes.NumberMultipleDecimalPoints,
                     {
                         start,
-                        end: i + 1
+                        end: i
                     },
                     { n: numberOfDecimalPointsEncountered }
                 );
 
             if (i + 1 < length) char = input[--i]; // We went one too far, so let's go back.
 
-            output.push([str, { type: TokenTypes.Number, position: { start, end: i + 1 } }]);
+            output.push([str, { type: TokenTypes.Number, position: { start, end: i } }]);
             continue;
         }
 
@@ -221,7 +220,7 @@ export default function lex(input: string): Token[] {
                         ZircoSyntaxErrorTypes.UnclosedBlockComment,
                         {
                             start,
-                            end: i + 1
+                            end: i
                         },
                         {}
                     );
@@ -249,7 +248,7 @@ export default function lex(input: string): Token[] {
 
             if (i + 1 < length) char = input[--i]; // We went one too far, so let's go back.
 
-            output.push([str, { type: TokenTypes.Name, position: { start, end: i + 1 } }]);
+            output.push([str, { type: TokenTypes.Name, position: { start, end: i } }]);
             continue;
         }
 
@@ -275,7 +274,7 @@ export default function lex(input: string): Token[] {
 
             if (didMatchCurrent) {
                 // We found a match! Let's add it to the output.
-                output.push([op, { type: TokenTypes.Operator, position: { start: i, end: i + op.length } }]);
+                output.push([op, { type: TokenTypes.Operator, position: { start: i, end: i + op.length - 1 } }]);
                 i += op.length - 1;
                 didMatchAnyOperator = true;
                 break;
@@ -289,12 +288,12 @@ export default function lex(input: string): Token[] {
         const singleCharOperators = ["+", "-", "*", "/", "%", "=", "!", "<", ">", "(", ")", "{", "}", "[", "]", ",", ";", ":", "."];
 
         if (singleCharOperators.includes(char)) {
-            output.push([char, { type: TokenTypes.Operator, position: { start: i, end: i + 1 } }]);
+            output.push([char, { type: TokenTypes.Operator, position: { start: i, end: i } }]);
             continue;
         }
 
         // Anything else is an OTHER
-        output.push([char, { type: TokenTypes.Other, position: { start: i, end: i + 1 } }]);
+        output.push([char, { type: TokenTypes.Other, position: { start: i, end: i } }]);
     }
     return output;
 }

--- a/src/lexer/tests/index.test.ts
+++ b/src/lexer/tests/index.test.ts
@@ -17,15 +17,8 @@
  */
 
 import lex from "../index";
-import { TokenTypes } from "../lex";
+import lexDirectly from "../lex";
 
 describe("lexer export", () => {
-    it("works as expected", () =>
-        expect(lex("2 + 2 = 4")).toEqual([
-            ["2", { type: TokenTypes.Number, position: { start: 0, end: 1 } }],
-            ["+", { type: TokenTypes.Operator, position: { start: 2, end: 3 } }],
-            ["2", { type: TokenTypes.Number, position: { start: 4, end: 5 } }],
-            ["=", { type: TokenTypes.Operator, position: { start: 6, end: 7 } }],
-            ["4", { type: TokenTypes.Number, position: { start: 8, end: 9 } }]
-        ]));
+    it("works as expected", () => expect(lex("2 + 2 = 4")).toEqual(lexDirectly("2 + 2 = 4")));
 });

--- a/src/lexer/tests/lex.test.ts
+++ b/src/lexer/tests/lex.test.ts
@@ -25,146 +25,146 @@ describe("lex", () => {
     it("returns none on an empty input", () => expect(lex("")).toEqual([]));
     describe("simple tokens", () => {
         it("classifies a single letter as an identifier", () =>
-            expect(lex("a")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }]]));
+            expect(lex("a")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }]]));
         it("classifies a single number as a constant", () =>
-            expect(lex("1")).toEqual([["1", { type: TokenTypes.Number, position: { start: 0, end: 1 } }]]));
+            expect(lex("1")).toEqual([["1", { type: TokenTypes.Number, position: { start: 0, end: 0 } }]]));
         it("classifies a single-letter string as a string", () =>
-            expect(lex('"a"')).toEqual([['"a"', { type: TokenTypes.String, position: { start: 0, end: 3 } }]]));
+            expect(lex('"a"')).toEqual([['"a"', { type: TokenTypes.String, position: { start: 0, end: 2 } }]]));
         describe("strings with weird traits", () => {
             it("errors on string with no end", () =>
                 expect(() => lex('"')).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.UnclosedString, {
                     start: 0,
-                    end: 1
+                    end: 0
                 }));
             it("should error provided a non-closed string with an escape", () =>
                 expect(() => lex('"a\\')).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.UnclosedString, {
                     start: 2,
-                    end: 3
+                    end: 2
                 }));
             it("escaped EOF", () =>
                 expect(() => lex('"\\"')).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.UnclosedString, {
                     start: 0,
-                    end: 3
+                    end: 2
                 }));
             it("works with escaped quote", () =>
-                expect(lex('"\\""')).toEqual([['"\\""', { type: TokenTypes.String, position: { start: 0, end: 4 } }]]));
+                expect(lex('"\\""')).toEqual([['"\\""', { type: TokenTypes.String, position: { start: 0, end: 3 } }]]));
         });
         describe("numerical constant types", () => {
             it("classifies a decimal number as a constant", () =>
-                expect(lex("111")).toEqual([["111", { type: TokenTypes.Number, position: { start: 0, end: 3 } }]]));
+                expect(lex("111")).toEqual([["111", { type: TokenTypes.Number, position: { start: 0, end: 2 } }]]));
             it("classifies a hexadecimal number as a constant", () =>
-                expect(lex("0xFF")).toEqual([["0xFF", { type: TokenTypes.Number, position: { start: 0, end: 4 } }]]));
+                expect(lex("0xFF")).toEqual([["0xFF", { type: TokenTypes.Number, position: { start: 0, end: 3 } }]]));
             it("classifies a binary number as a constant", () =>
-                expect(lex("0b11")).toEqual([["0b11", { type: TokenTypes.Number, position: { start: 0, end: 4 } }]]));
+                expect(lex("0b11")).toEqual([["0b11", { type: TokenTypes.Number, position: { start: 0, end: 3 } }]]));
             it("classifies a number with a decimal as a constant", () =>
-                expect(lex("1.3")).toEqual([["1.3", { type: TokenTypes.Number, position: { start: 0, end: 3 } }]]));
+                expect(lex("1.3")).toEqual([["1.3", { type: TokenTypes.Number, position: { start: 0, end: 2 } }]]));
             it("should error when given a non-binary value in a binary constant", () =>
                 expect(() => lex("0b2")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberInvalidCharacter, {
                     start: 2,
-                    end: 3
+                    end: 2
                 }));
             it("should error given a Z in a hex", () =>
                 expect(() => lex("0xZ")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberInvalidCharacter, {
                     start: 2,
-                    end: 3
+                    end: 2
                 }));
         });
-        it("operator", () => expect(lex("+")).toEqual([["+", { type: TokenTypes.Operator, position: { start: 0, end: 1 } }]]));
+        it("operator", () => expect(lex("+")).toEqual([["+", { type: TokenTypes.Operator, position: { start: 0, end: 0 } }]]));
     });
     describe("whitespace trimming", () => {
         // In this case, it's expected that multiple spaces are merged and start/end indicate them safely.
         it("one space between NAME tokens", () =>
             expect(lex("a b")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 2, end: 3 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 2, end: 2 } }]
             ]));
         it("space between CONSTANT_NUMBERs", () =>
             expect(lex("1 2")).toEqual([
-                ["1", { type: TokenTypes.Number, position: { start: 0, end: 1 } }],
-                ["2", { type: TokenTypes.Number, position: { start: 2, end: 3 } }]
+                ["1", { type: TokenTypes.Number, position: { start: 0, end: 0 } }],
+                ["2", { type: TokenTypes.Number, position: { start: 2, end: 2 } }]
             ]));
         it("space between hexadecimal CONSTANT_NUMBERs", () =>
             expect(lex("0xF 0xF")).toEqual([
-                ["0xF", { type: TokenTypes.Number, position: { start: 0, end: 3 } }],
-                ["0xF", { type: TokenTypes.Number, position: { start: 4, end: 7 } }]
+                ["0xF", { type: TokenTypes.Number, position: { start: 0, end: 2 } }],
+                ["0xF", { type: TokenTypes.Number, position: { start: 4, end: 6 } }]
             ]));
         it("space between STRINGs", () =>
             expect(lex('"a" "b"')).toEqual([
-                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 3 } }],
-                ['"b"', { type: TokenTypes.String, position: { start: 4, end: 7 } }]
+                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 2 } }],
+                ['"b"', { type: TokenTypes.String, position: { start: 4, end: 6 } }]
             ]));
         it("one tab between tokens", () =>
             expect(lex("a\tb")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 2, end: 3 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 2, end: 2 } }]
             ]));
         it("one newline between tokens", () =>
             expect(lex("a\nb")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 2, end: 3 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 2, end: 2 } }]
             ]));
         it("multiple spaces between tokens", () =>
             expect(lex("a  b")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 3, end: 4 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 3, end: 3 } }]
             ]));
     });
     describe("more complex cases", () => {
-        it("identifier with a number", () => expect(lex("a1")).toEqual([["a1", { type: TokenTypes.Name, position: { start: 0, end: 2 } }]]));
+        it("identifier with a number", () => expect(lex("a1")).toEqual([["a1", { type: TokenTypes.Name, position: { start: 0, end: 1 } }]]));
         it("sequential non-operator symbols are separate", () =>
             expect(lex("$$")).toEqual([
-                ["$", { type: TokenTypes.Other, position: { start: 0, end: 1 } }],
-                ["$", { type: TokenTypes.Other, position: { start: 1, end: 2 } }]
+                ["$", { type: TokenTypes.Other, position: { start: 0, end: 0 } }],
+                ["$", { type: TokenTypes.Other, position: { start: 1, end: 1 } }]
             ]));
         it("letter in a number", () =>
             expect(() => lex("1a")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberInvalidCharacter, {
                 start: 1,
-                end: 2
+                end: 1
             }));
         it("no whitespace change in token type", () =>
             expect(lex("a+b")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["+", { type: TokenTypes.Operator, position: { start: 1, end: 2 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 2, end: 3 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["+", { type: TokenTypes.Operator, position: { start: 1, end: 1 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 2, end: 2 } }]
             ]));
         it("whitespace change in token type", () =>
             expect(lex("a + b")).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ["+", { type: TokenTypes.Operator, position: { start: 2, end: 3 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 4, end: 5 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ["+", { type: TokenTypes.Operator, position: { start: 2, end: 2 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 4, end: 4 } }]
             ]));
         it("multiple sequential decimals should fail", () =>
             expect(() => lex("1..")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberMultipleDecimalPoints, {
                 start: 0,
-                end: 3
+                end: 2
             }));
         it("multiple decimals should fail", () =>
             expect(() => lex("1.2.")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberMultipleDecimalPoints, {
                 start: 0,
-                end: 4
+                end: 3
             }));
         it("opening but not a value for a constant number", () =>
             expect(() => lex("0x")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.NumberPrefixWithNoValue, {
                 start: 1,
-                end: 2
+                end: 1
             }));
         it("sequential strings", () =>
             expect(lex('"a""b"')).toEqual([
-                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 3 } }],
-                ['"b"', { type: TokenTypes.String, position: { start: 3, end: 6 } }]
+                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 2 } }],
+                ['"b"', { type: TokenTypes.String, position: { start: 3, end: 5 } }]
             ]));
         it("string then identifier", () =>
             expect(lex('"a"b')).toEqual([
-                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 3 } }],
-                ["b", { type: TokenTypes.Name, position: { start: 3, end: 4 } }]
+                ['"a"', { type: TokenTypes.String, position: { start: 0, end: 2 } }],
+                ["b", { type: TokenTypes.Name, position: { start: 3, end: 3 } }]
             ]));
         it("identifier then string", () =>
             expect(lex('a"b"')).toEqual([
-                ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                ['"b"', { type: TokenTypes.String, position: { start: 1, end: 4 } }]
+                ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                ['"b"', { type: TokenTypes.String, position: { start: 1, end: 3 } }]
             ]));
 
-        it("underscores in numbers", () => expect(lex("1_2")).toEqual([["1_2", { type: TokenTypes.Number, position: { start: 0, end: 3 } }]]));
+        it("underscores in numbers", () => expect(lex("1_2")).toEqual([["1_2", { type: TokenTypes.Number, position: { start: 0, end: 2 } }]]));
     });
 
     describe("comments", () => {
@@ -173,45 +173,45 @@ describe("lex", () => {
             it("simple single-line on its own (w/o space)", () => expect(lex("//a")).toEqual([]));
             it("simple single-line with trailing space", () => expect(lex("// a ")).toEqual([]));
             it("simple single line with token before", () =>
-                expect(lex("a// b")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }]]));
+                expect(lex("a// b")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }]]));
             it("simple single line with token before (+ space)", () =>
-                expect(lex("a /// b")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }]]));
+                expect(lex("a /// b")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }]]));
         });
         describe("multi-line", () => {
             it("on its own", () => expect(lex("/*a*/")).toEqual([]));
-            it("with token before", () => expect(lex("a/*a*/")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }]]));
-            it("with token after", () => expect(lex("/*a*/a")).toEqual([["a", { type: TokenTypes.Name, position: { start: 5, end: 6 } }]]));
+            it("with token before", () => expect(lex("a/*a*/")).toEqual([["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }]]));
+            it("with token after", () => expect(lex("/*a*/a")).toEqual([["a", { type: TokenTypes.Name, position: { start: 5, end: 5 } }]]));
             it("with token before and after", () =>
                 expect(lex("a/*a*/a")).toEqual([
-                    ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                    ["a", { type: TokenTypes.Name, position: { start: 6, end: 7 } }]
+                    ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                    ["a", { type: TokenTypes.Name, position: { start: 6, end: 6 } }]
                 ]));
             it("with nesting", () => expect(lex("/*a/*a*/a*/")).toEqual([]));
             it("unclosed", () =>
                 expect(() => lex("/*a")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.UnclosedBlockComment, {
                     start: 0,
-                    end: 3
+                    end: 2
                 }));
             it("unclosed (nested)", () =>
                 expect(() => lex("/*a/*a")).toThrowZircoError(ZircoSyntaxError, ZircoSyntaxErrorTypes.UnclosedBlockComment, {
                     start: 0,
-                    end: 6
+                    end: 5
                 }));
             it("newline case", () =>
                 expect(lex("a\n//a\na")).toEqual([
-                    ["a", { type: TokenTypes.Name, position: { start: 0, end: 1 } }],
-                    ["a", { type: TokenTypes.Name, position: { start: 6, end: 7 } }]
+                    ["a", { type: TokenTypes.Name, position: { start: 0, end: 0 } }],
+                    ["a", { type: TokenTypes.Name, position: { start: 6, end: 6 } }]
                 ]));
             it("block comment start marker within a line-comment", () => expect(lex("///*")).toEqual([]));
             it("un-started block comment end", () =>
                 expect(lex("*/")).toEqual([
-                    ["*", { type: TokenTypes.Operator, position: { start: 0, end: 1 } }],
-                    ["/", { type: TokenTypes.Operator, position: { start: 1, end: 2 } }]
+                    ["*", { type: TokenTypes.Operator, position: { start: 0, end: 0 } }],
+                    ["/", { type: TokenTypes.Operator, position: { start: 1, end: 1 } }]
                 ]));
         });
     });
 
-    describe("multi-character operators", () => {
+    describe("two-character operators", () => {
         const MC_OPS = [
             ["addition assignment", "+="],
             ["subtraction assignment", "-="],
@@ -230,6 +230,6 @@ describe("lex", () => {
             ["exponent", "**"]
         ];
         for (const [name, op] of MC_OPS)
-            it(name, () => expect(lex(op)).toEqual([[op, { type: TokenTypes.Operator, position: { start: 0, end: 2 } }]]));
+            it(name, () => expect(lex(op)).toEqual([[op, { type: TokenTypes.Operator, position: { start: 0, end: 1 } }]]));
     });
 });


### PR DESCRIPTION
Instead of treating a token `0xFF` as the following:

```
 0 x F F
| | | | |
0 1 2 3 4
start: 0
end: 4
```

we treat it as:
```
0 x F F
| | | |
0 1 2 3
start: 0
end: 3
```

Basically, we make the `end` point to the *last* character of the match instead of the character after it.